### PR TITLE
Updating Jackson version to address CVE-2019-14540 and CVE-2019-16335

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.2</version>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
GitHub security alerts are flagging the version of Jackson used in the test scope as vulnerable:

CVE-2019-14540 Critical severity
CVE-2019-16335 Critical severity

This affects all versions of Jackson below 2.9.10, so updating to 2.10.0 to address this. 2.10.0 still has the same JDK compatibility as 2.9.x.