### PR TITLE
Remove any line separators from the key data

### DIFF
--- a/src/main/java/com/mastercard/developer/utils/EncryptionUtils.java
+++ b/src/main/java/com/mastercard/developer/utils/EncryptionUtils.java
@@ -47,6 +47,7 @@ public final class EncryptionUtils {
             // OpenSSL / PKCS#1 Base64 PEM encoded file
             keyDataString = keyDataString.replace(PKCS_1_PEM_HEADER, "");
             keyDataString = keyDataString.replace(PKCS_1_PEM_FOOTER, "");
+            keyDataString = keyDataString.replace(System.lineSeparator(), "");
             return readPkcs1PrivateKey(base64Decode(keyDataString));
         }
 
@@ -54,6 +55,7 @@ public final class EncryptionUtils {
             // PKCS#8 Base64 PEM encoded file
             keyDataString = keyDataString.replace(PKCS_8_PEM_HEADER, "");
             keyDataString = keyDataString.replace(PKCS_8_PEM_FOOTER, "");
+            keyDataString = keyDataString.replace(System.lineSeparator(), "");
             return readPkcs8PrivateKey(base64Decode(keyDataString));
         }
 


### PR DESCRIPTION
This allows folks to use the java.util.Base64 (at least under Java8) which doesn't handle the line separators.
Thanks much for the code!