### PR TITLE
refactor: move the base64UrlEncode out of JweObject

### DIFF
--- a/src/main/java/com/mastercard/developer/utils/EncodingUtils.java
+++ b/src/main/java/com/mastercard/developer/utils/EncodingUtils.java
@@ -63,4 +63,11 @@ public class EncodingUtils {
         }
         return Base64.getEncoder().encodeToString(bytes);
     }
+
+    /**
+     * BASE64URL as per https://datatracker.ietf.org/doc/html/rfc7515#appendix-C
+     */
+    public static String base64UrlEncode(byte[] bytes) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
 }

--- a/src/test/java/com/mastercard/developer/utils/EncodingUtilsTest.java
+++ b/src/test/java/com/mastercard/developer/utils/EncodingUtilsTest.java
@@ -67,4 +67,11 @@ public class EncodingUtilsTest {
     public void testBase64Decode_ShouldThrowIllegalArgumentException_WhenNullValue() {
         EncodingUtils.base64Decode(null);
     }
+
+    @Test
+    public void testBase64UrlEncode() {
+        Assert.assertEquals("AA", EncodingUtils.base64UrlEncode(new byte[1]));
+        Assert.assertEquals("eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ", EncodingUtils.base64UrlEncode("{\"alg\":\"RSA-OAEP\",\"enc\":\"A256GCM\"}".getBytes()));
+        Assert.assertEquals("bGlnaHQgd29yaw", EncodingUtils.base64UrlEncode("light work".getBytes()));
+    }
 }


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [ ] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: *add the link here*

#### Description
Move the base64Url encode function out of the JweObject class since it is a general Encoding function.
Add tests for the same.
