### PR TITLE
encryption of JWE on README Example should work in both ways

### DIFF
--- a/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
+++ b/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
@@ -94,7 +94,7 @@ public class JweEncryption {
         }
 
         // Read and remove encrypted data and encryption fields at the given JSON path
-        Object encryptedValueJsonElement = readAndDeleteJsonKey(payloadContext, inJsonObject, config.encryptedValueFieldName);
+        Object encryptedValueJsonElement = JsonPath.parse(inJsonObject).read(config.encryptedValueFieldName);
         if (jsonEngine.isNullOrEmptyJson(encryptedValueJsonElement)) {
             // Nothing to decrypt
             return payloadContext;
@@ -117,11 +117,6 @@ public class JweEncryption {
         // Remove the input
         payloadContext.delete(jsonPathIn);
         return payloadContext;
-    }
-
-    private static Object readAndDeleteJsonKey(DocumentContext context, Object object, String key) {
-        context.delete(key);
-        return object;
     }
 
     private static Object readJsonObject(DocumentContext context, String jsonPathString) {

--- a/src/test/java/com/mastercard/developer/encryption/JweEncryptionWithDefaultJsonEngineTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/JweEncryptionWithDefaultJsonEngineTest.java
@@ -19,7 +19,7 @@ public class JweEncryptionWithDefaultJsonEngineTest {
                 "]";
         JweConfig config = getTestJweConfigBuilder()
                 .withEncryptionPath("$", "$")
-                .withDecryptionPath("$.encryptedData", "$")
+                .withDecryptionPath("$", "$")
                 .build();
 
         // WHEN
@@ -39,7 +39,7 @@ public class JweEncryptionWithDefaultJsonEngineTest {
                 "    \"encryptedData\": \"eyJraWQiOiI3NjFiMDAzYzFlYWRlM2E1NDkwZTUwMDBkMzc4ODdiYWE1ZTZlYzBlMjI2YzA3NzA2ZTU5OTQ1MWZjMDMyYTc5IiwiY3R5IjoiYXBwbGljYXRpb24vanNvbiIsImVuYyI6IkEyNTZHQ00iLCJhbGciOiJSU0EtT0FFUC0yNTYifQ.IcTIce59pgtjODJn4PhR7oK3F-gxcd7dishTrT7T9y5VC0U5ZS_JdMoRe59_UTkJMY8Nykb2rv3Oh_jSDYRmGB_CWMIciXYMLHQptLTF5xI1ZauDPnooDMWoOCBD_d3I0wTJNcM7I658rK0ZWSByVK9YqhEo8UaIf4e6egRHQdZ2_IGKgICwmglv_uXQrYewOWFTKR1uMpya1N50MDnWax2NtnW3SljP3mARUBLBnRmOyubQCg-Mgn8fsOWWXm-KL9RrQq9AF_HJceoJl1rRgzPW7g6SLK6EjiGW_ArTmrLaOHg9bYOY_LrbyokK_M1pMo9qup70DHvjHkMZqIL3aQ.vtma3jBIo2STkquxTUX9PQ.9ZoQG0sFvQ.ms4bW3OFd03neRlex-zZ8w\"" +
                 "}";
         JweConfig config = getTestJweConfigBuilder()
-                .withDecryptionPath("$.encryptedData", "$")
+                .withDecryptionPath("$", "$")
                 .build();
 
         // WHEN
@@ -48,4 +48,28 @@ public class JweEncryptionWithDefaultJsonEngineTest {
         // THEN
         assertPayloadEquals("[{},{}]", payload);
     }
+
+    @Test
+    public void testReadMeSample() throws Exception {
+        JweConfig config = getTestJweConfigBuilder()
+                .withEncryptionPath("$.path.to.foo", "$.path.to.encryptedFoo")
+                .withDecryptionPath("$.path.to.encryptedFoo", "$.path.to.foo")
+                .build();
+
+        String payload = "{" +
+        "    \"path\": {" +
+        "        \"to\": {" +
+        "            \"foo\": {" +
+        "                \"sensitiveField1\": \"sensitiveValue1\"," +
+        "                \"sensitiveField2\": \"sensitiveValue2\"" +
+        "            }" +
+        "        }" +
+        "    }" +
+        "}";
+
+        String encryptedPayload = JweEncryption.encryptPayload(payload, config);
+        String decryptedPayload = JweEncryption.decryptPayload(encryptedPayload, config);
+
+        assertPayloadEquals(payload, decryptedPayload);
+    }        
 }


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [ ] An issue/feature request has been created for this PR
- [ ] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: *add the link here*

#### Description
At first, I was confused when I encountered this our code couldn't pass this test below.

```
    @Test
    public void testReadMeSample() throws Exception {
        JweConfig config = getTestJweConfigBuilder()
                .withEncryptionPath("$.path.to.foo", "$.path.to.encryptedFoo")
                .withDecryptionPath("$.path.to.encryptedFoo", "$.path.to.foo")
                .build();

        String payload = "{" +
        "    \"path\": {" +
        "        \"to\": {" +
        "            \"foo\": {" +
        "                \"sensitiveField1\": \"sensitiveValue1\"," +
        "                \"sensitiveField2\": \"sensitiveValue2\"" +
        "            }" +
        "        }" +
        "    }" +
        "}";

        String encryptedPayload = JweEncryption.encryptPayload(payload, config);
        String decryptedPayload = JweEncryption.decryptPayload(encryptedPayload, config);

        assertPayloadEquals(payload, decryptedPayload);
    }        
```

I think encryptedValueFieldName can be confused when we designate en/decryption path over JweConfig.

I am not 100% this is the right way though. I would like to discuss it with you guys.