### PR TITLE
Adding support for wildcard encryption and decryption paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ This library supports two types of encryption/decryption, both of which support 
 + [Performing JWE Decryption](#performing-jwe-decryption)
 + [Encrypting Entire Payloads](#encrypting-entire-payloads-jwe)
 + [Decrypting Entire Payloads](#decrypting-entire-payloads-jwe)
++ [Encrypting Payloads with Wildcards](#encrypting-wildcard-payloads-jwe)
++ [Decrypting Payloads with Wildcards](#decrypting-wildcard-payloads-jwe)
 
 ##### • Introduction <a name="jwe-introduction"></a>
 
@@ -294,6 +296,70 @@ Output:
 }
 ```
 
+##### • Encrypting Payloads with Wildcards <a name="encrypting-wildcard-payloads-jwe"></a>
+
+Wildcards can be encrypted using the "[*]" operator as part of encryption path:
+
+```java
+JweConfig config = JweConfigBuilder.aJweEncryptionConfig()
+    .withEncryptionCertificate(encryptionCertificate)
+    .withEncryptionPath("$.list[*]sensitiveField1", "$.list[*]encryptedField")
+    // …
+    .build();
+```
+
+Example:
+```java
+String payload = "{ \"list\": [ " +
+    "   { \"sensitiveField1\" : \"sensitiveValue1\"}, "+
+    "   { \"sensitiveField1\" : \"sensitiveValue2\"} " +
+    "]}";
+String encryptedPayload = JweEncryption.encryptPayload(payload, config);
+System.out.println(new GsonBuilder().setPrettyPrinting().create().toJson(new JsonParser().parse(encryptedPayload)));
+```
+
+Output:
+```json
+{
+  "list": [
+    {"encryptedField": "eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+oPYKZEMTKyYcSIVEgtQw"},
+    {"encryptedField": "eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+asdvarvasdvfdvakmkmm"}
+  ]
+}
+```
+
+##### • Decrypting Payloads with Wildcards <a name="decrypting-wildcard-payloads-jwe"></a>
+
+Wildcards can be decrypted using the "[*]" operator as part of decryption path:
+
+```java
+JweConfig config = JweConfigBuilder.aJweEncryptionConfig()
+    .withDecryptionKey(decryptionKey)
+    .withDecryptionPath("$.list[*]encryptedField", "$.list[*]sensitiveField1")
+    // …
+    .build();
+```
+
+Example:
+```java
+String encryptedPayload = "{ \"list\": [ " +
+        " { \"encryptedField\": \"eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+oPYKZEMTKyYcSIVEgtQw\"}, " +
+        " { \"encryptedField\": \"eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+asdvarvasdvfdvakmkmm\"} " +
+        " ]}";
+String payload = JweEncryption.decryptPayload(encryptedPayload, config);
+System.out.println(new GsonBuilder().setPrettyPrinting().create().toJson(new JsonParser().parse(payload)));
+```
+
+Output:
+```json
+{
+  "list": [
+    {"sensitiveField1": "sensitiveValue1"},
+    {"sensitiveField2": "sensitiveValue2"}
+  ]
+}
+```
+
 #### Mastercard Encryption and Decryption <a name="mastercard-encryption-and-decryption"></a>
 
 + [Introduction](#mastercard-introduction)
@@ -302,6 +368,8 @@ Output:
 + [Performing Mastercard Decryption](#performing-mastercard-decryption)
 + [Encrypting Entire Payloads](#encrypting-entire-mastercard-payloads)
 + [Decrypting Entire Payloads](#decrypting-entire-mastercard-payloads)
++ [Encrypting Payloads with Wildcards](#encrypting-wildcard-mastercard-payloads)
++ [Decrypting Payloads with Wildcards](#decrypting-wildcard-mastercard-payloads)
 + [Using HTTP Headers for Encryption Params](#using-http-headers-for-encryption-params)
 
 ##### • Introduction <a name="mastercard-introduction"></a>
@@ -468,6 +536,70 @@ Output:
 {
     "sensitiveField1": "sensitiveValue1",
     "sensitiveField2": "sensitiveValue2"
+}
+
+```
+##### • Encrypting Payloads with Wildcards <a name="encrypting-wildcard-mastercard-payloads"></a>
+
+Wildcards can be encrypted using the "[*]" operator as part of encryption path:
+
+```java
+FLEConfig config = FieldLevelEncryptionConfigBuilder.aFieldLevelEncryptionConfig()
+    .withEncryptionCertificate(encryptionCertificate)
+    .withEncryptionPath("$.list[*]sensitiveField1", "$.list[*]encryptedField")
+    // …
+    .build();
+```
+
+Example:
+```java
+String payload = "{ \"list\": [ " +
+    "   { \"sensitiveField1\" : \"sensitiveValue1\"}, "+
+    "   { \"sensitiveField1\" : \"sensitiveValue2\"} " +
+    "]}";
+String encryptedPayload = FieldLevelEncryption.encryptPayload(payload, config);
+System.out.println(new GsonBuilder().setPrettyPrinting().create().toJson(new JsonParser().parse(encryptedPayload)));
+```
+
+Output:
+```json
+{
+  "list": [
+    {"encryptedField": "eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+oPYKZEMTKyYcSIVEgtQw"},
+    {"encryptedField": "eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+asdvarvasdvfdvakmkmm"}
+  ]
+}
+```
+
+##### • Decrypting Payloads with Wildcards <a name="decrypting-wildcard-mastercard-payloads"></a>
+
+Wildcards can be decrypted using the "[*]" operator as part of decryption path:
+
+```java
+FLEConfig config = FieldLevelEncryptionConfigBuilder.aFieldLevelEncryptionConfig()
+    .withDecryptionKey(decryptionKey)
+    .withDecryptionPath("$.list[*]encryptedField", "$.list[*]sensitiveField1")
+    // …
+    .build();
+```
+
+Example:
+```java
+String encryptedPayload = "{ \"list\": [ " +
+        " { \"encryptedField\": \"eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+oPYKZEMTKyYcSIVEgtQw\"}, " +
+        " { \"encryptedField\": \"eyJraWQiOiI3NjFiMDAzYzFlYWRlM….Y+asdvarvasdvfdvakmkmm\"} " +
+        " ]}";
+String payload = FieldLevelEncryption.decryptPayload(encryptedPayload, config);
+System.out.println(new GsonBuilder().setPrettyPrinting().create().toJson(new JsonParser().parse(payload)));
+```
+
+Output:
+```json
+{
+  "list": [
+    {"sensitiveField1": "sensitiveValue1"},
+    {"sensitiveField2": "sensitiveValue2"}
+  ]
 }
 ```
 

--- a/src/main/java/com/mastercard/developer/encryption/EncryptionConfigBuilder.java
+++ b/src/main/java/com/mastercard/developer/encryption/EncryptionConfigBuilder.java
@@ -42,14 +42,32 @@ abstract class EncryptionConfigBuilder {
 
     void checkJsonPathParameterValues() {
         for (Map.Entry<String, String> entry : decryptionPaths.entrySet()) {
-            if (!JsonPath.isPathDefinite(entry.getKey()) || !JsonPath.isPathDefinite(entry.getValue())) {
-                throw new IllegalArgumentException("JSON paths for decryption must point to a single item!");
+            if(entry.getKey().contains("[*]") || entry.getValue().contains("[*]")){
+                if(!(entry.getKey().contains("[*]") && entry.getValue().contains("[*]"))){
+                    throw new IllegalArgumentException("JSON paths for decryption with wildcard must both contain a wildcard!");
+                }
+                if((entry.getKey().split("[*]", -1).length-1 > 1 || entry.getValue().split("[*]", -1).length-1 > 1)){
+                    throw new IllegalArgumentException("JSON paths for decryption with can only contain one wildcard!");
+                }
+            } else {
+                if (!JsonPath.isPathDefinite(entry.getKey()) || !JsonPath.isPathDefinite(entry.getValue())) {
+                    throw new IllegalArgumentException("JSON paths for decryption must point to a single item!");
+                }
             }
         }
 
         for (Map.Entry<String, String> entry : encryptionPaths.entrySet()) {
-            if (!JsonPath.isPathDefinite(entry.getKey()) || !JsonPath.isPathDefinite(entry.getValue())) {
-                throw new IllegalArgumentException("JSON paths for encryption must point to a single item!");
+            if(entry.getKey().contains("[*]") || entry.getValue().contains("[*]")){
+                if(!(entry.getKey().contains("[*]") && entry.getValue().contains("[*]"))){
+                    throw new IllegalArgumentException("JSON paths for encryption with wildcard must both contain a wildcard!");
+                }
+                if((entry.getKey().split("[*]", -1).length-1 > 1 || entry.getValue().split("[*]", -1).length-1 > 1)){
+                    throw new IllegalArgumentException("JSON paths for encryption with can only contain one wildcard!");
+                }
+            } else {
+                if (!JsonPath.isPathDefinite(entry.getKey()) || !JsonPath.isPathDefinite(entry.getValue())) {
+                    throw new IllegalArgumentException("JSON paths for encryption must point to a single item!");
+                }
             }
         }
     }

--- a/src/main/java/com/mastercard/developer/encryption/FieldLevelEncryption.java
+++ b/src/main/java/com/mastercard/developer/encryption/FieldLevelEncryption.java
@@ -38,7 +38,17 @@ public class FieldLevelEncryption {
             for (Entry<String, String> entry : config.encryptionPaths.entrySet()) {
                 String jsonPathIn = entry.getKey();
                 String jsonPathOut = entry.getValue();
-                payloadContext = encryptPayloadPath(payloadContext, jsonPathIn, jsonPathOut, config, (FieldLevelEncryptionParams) params);
+                if(!jsonPathIn.contains("[*]")){
+                    payloadContext = encryptPayloadPath(payloadContext, jsonPathIn, jsonPathOut, config, (FieldLevelEncryptionParams) params);
+                }else {
+                    String getFieldLength = jsonPathIn.split("\\[.*?\\]")[0].concat(".length()");
+                    Integer length = JsonPath.read(payload, getFieldLength);
+                    for (Integer i = 0; i < length; i++) {
+                        String newJsonPathIn = jsonPathIn.replace("*", i.toString());
+                        String newJsonPathOut = jsonPathOut.replace("*", i.toString());
+                        payloadContext = encryptPayloadPath(payloadContext, newJsonPathIn, newJsonPathOut, config, (FieldLevelEncryptionParams) params);
+                    }
+                }
             }
 
             // Return the updated payload
@@ -61,7 +71,17 @@ public class FieldLevelEncryption {
             for (Entry<String, String> entry : config.decryptionPaths.entrySet()) {
                 String jsonPathIn = entry.getKey();
                 String jsonPathOut = entry.getValue();
-                payloadContext = decryptPayloadPath(payloadContext, jsonPathIn, jsonPathOut, config, (FieldLevelEncryptionParams) params);
+                if(!jsonPathIn.contains("[*]")){
+                    payloadContext = decryptPayloadPath(payloadContext, jsonPathIn, jsonPathOut, config, (FieldLevelEncryptionParams) params);
+                }else {
+                    String getFieldLength = jsonPathIn.split("\\[.*?\\]")[0].concat(".length()");
+                    Integer length = JsonPath.read(payload, getFieldLength);
+                    for (Integer i = 0; i < length; i++) {
+                        String newJsonPathIn = jsonPathIn.replace("*", i.toString());
+                        String newJsonPathOut = jsonPathOut.replace("*", i.toString());
+                        payloadContext = decryptPayloadPath(payloadContext, newJsonPathIn, newJsonPathOut, config, (FieldLevelEncryptionParams) params);
+                    }
+                }
             }
 
             // Return the updated payload

--- a/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
+++ b/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
@@ -30,7 +30,17 @@ public class JweEncryption {
             for (Map.Entry<String, String> entry : config.getEncryptionPaths().entrySet()) {
                 String jsonPathIn = entry.getKey();
                 String jsonPathOut = entry.getValue();
-                payloadContext = encryptPayloadPath(payloadContext, jsonPathIn, jsonPathOut, config);
+                if(!jsonPathIn.contains("[*]")){
+                    payloadContext = encryptPayloadPath(payloadContext, jsonPathIn, jsonPathOut, config);
+                }else {
+                    String getFieldLength = jsonPathIn.split("\\[.*?\\]")[0].concat(".length()");
+                    Integer length = JsonPath.read(payload, getFieldLength);
+                    for (Integer i = 0; i < length; i++) {
+                        String newJsonPathIn = jsonPathIn.replace("*", i.toString());
+                        String newJsonPathOut = jsonPathOut.replace("*", i.toString());
+                        payloadContext = encryptPayloadPath(payloadContext, newJsonPathIn, newJsonPathOut, config);
+                    }
+                }
             }
 
             // Return the updated payload
@@ -49,7 +59,17 @@ public class JweEncryption {
             for (Map.Entry<String, String> entry : config.getDecryptionPaths().entrySet()) {
                 String jsonPathIn = entry.getKey();
                 String jsonPathOut = entry.getValue();
-                payloadContext = decryptPayloadPath(payloadContext, jsonPathIn, jsonPathOut, config);
+                if(!jsonPathIn.contains("[*]")){
+                    payloadContext = decryptPayloadPath(payloadContext, jsonPathIn, jsonPathOut, config);
+                }else {
+                    String getFieldLength = jsonPathIn.split("\\[.*?\\]")[0].concat(".length()");
+                    Integer length = JsonPath.read(payload, getFieldLength);
+                    for (Integer i = 0; i < length; i++) {
+                        String newJsonPathIn = jsonPathIn.replace("*", i.toString());
+                        String newJsonPathOut = jsonPathOut.replace("*", i.toString());
+                        payloadContext = decryptPayloadPath(payloadContext, newJsonPathIn, newJsonPathOut, config);
+                    }
+                }
             }
 
             // Return the updated payload

--- a/src/test/java/com/mastercard/developer/encryption/FieldLevelEncryptionConfigBuilderTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/FieldLevelEncryptionConfigBuilderTest.java
@@ -97,11 +97,47 @@ public class FieldLevelEncryptionConfigBuilderTest {
     }
 
     @Test
-    public void testBuild_ShouldThrowIllegalArgumentException_WhenNotDefiniteDecryptionPath() throws Exception {
+    public void testBuild_ShouldBuild_WhenHavingWildcardPaths() throws Exception {
+        FieldLevelEncryptionConfig config = FieldLevelEncryptionConfigBuilder.aFieldLevelEncryptionConfig()
+                .withEncryptionPath("$.encryptedPayloads[*]", "$.payload[*]")
+                .withEncryptionCertificate(TestUtils.getTestEncryptionCertificate())
+                .withEncryptionCertificateFingerprint("97A2FFE9F0D48960EF31E87FCD7A55BF7843FB4A9EEEF01BDB6032AD6FEF146B")
+                .withEncryptionKeyFingerprint("F806B26BC4870E26986C70B6590AF87BAF4C2B56BB50622C51B12212DAFF2810")
+                .withEncryptionCertificateFingerprintFieldName("publicCertificateFingerprint")
+                .withEncryptionCertificateFingerprintHeaderName("x-public-certificate-fingerprint")
+                .withEncryptionKeyFingerprintFieldName("publicKeyFingerprint")
+                .withEncryptionKeyFingerprintHeaderName("x-public-key-fingerprint")
+                .withDecryptionPath("$.encryptedPayloads[*]", "$.payload[*]")
+                .withDecryptionKey(TestUtils.getTestDecryptionKey())
+                .withOaepPaddingDigestAlgorithm("SHA-512")
+                .withOaepPaddingDigestAlgorithmFieldName("oaepPaddingDigestAlgorithm")
+                .withOaepPaddingDigestAlgorithmHeaderName("x-oaep-padding-digest-algorithm")
+                .withEncryptedValueFieldName("encryptedValue")
+                .withEncryptedKeyFieldName("encryptedKey")
+                .withEncryptedKeyHeaderName("x-encrypted-key")
+                .withIvFieldName("iv")
+                .withIvHeaderName("x-iv")
+                .withFieldValueEncoding(HEX)
+                .build();
+        Assert.assertNotNull(config);
+    }
+
+    @Test
+    public void testBuild_ShouldThrowIllegalArgumentException_WhenNotHavingWildcardOnBothDecryptionPaths() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("JSON paths for decryption must point to a single item!");
+        expectedException.expectMessage("JSON paths for decryption with wildcard must both contain a wildcard!");
         FieldLevelEncryptionConfigBuilder.aFieldLevelEncryptionConfig()
                 .withDecryptionPath("$.encryptedPayloads[*]", "$.payload")
+                .withDecryptionKey(TestUtils.getTestDecryptionKey())
+                .build();
+    }
+
+    @Test
+    public void testBuild_ShouldThrowIllegalArgumentException_WhenMultipleWildcardsOnDecryptionPaths() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("JSON paths for decryption with can only contain one wildcard!");
+        FieldLevelEncryptionConfigBuilder.aFieldLevelEncryptionConfig()
+                .withDecryptionPath("$.encryptedPayloads[*]field1[*]subField", "$.payload[*]field1[*]encryptedSubField")
                 .withDecryptionKey(TestUtils.getTestDecryptionKey())
                 .build();
     }
@@ -121,11 +157,21 @@ public class FieldLevelEncryptionConfigBuilderTest {
     }
 
     @Test
-    public void testBuild_ShouldThrowIllegalArgumentException_WhenNotDefiniteEncryptionPath() throws Exception {
+    public void testBuild_ShouldThrowIllegalArgumentException_WhenNotHavingWildcardOnBothEncryptionPaths() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("JSON paths for encryption must point to a single item!");
+        expectedException.expectMessage("JSON paths for encryption with wildcard must both contain a wildcard!");
         FieldLevelEncryptionConfigBuilder.aFieldLevelEncryptionConfig()
-                .withEncryptionPath("$.payloads[*]", "$.encryptedPayload")
+                .withEncryptionPath("$.encryptedPayloads[*]", "$.payload")
+                .withEncryptionCertificate(TestUtils.getTestEncryptionCertificate())
+                .build();
+    }
+
+    @Test
+    public void testBuild_ShouldThrowIllegalArgumentException_WhenMultipleWildcardsOnEncryptionPaths() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("JSON paths for encryption with can only contain one wildcard!");
+        FieldLevelEncryptionConfigBuilder.aFieldLevelEncryptionConfig()
+                .withEncryptionPath("$.encryptedPayloads[*]field1[*]subField", "$.payload[*]field1[*]encryptedSubField")
                 .withEncryptionCertificate(TestUtils.getTestEncryptionCertificate())
                 .build();
     }

--- a/src/test/java/com/mastercard/developer/encryption/FieldLevelEncryptionWithDefaultJsonEngineTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/FieldLevelEncryptionWithDefaultJsonEngineTest.java
@@ -134,11 +134,11 @@ public class FieldLevelEncryptionWithDefaultJsonEngineTest {
         // GIVEN
         String payload = "{ \"fields\": [" +
                 "   {" +
-                "      \"field1\": \"1234\"," +
+                "      \"field1\": \"AAAA\"," +
                 "      \"field2\": \"asdf\"" +
                 "   }," +
                 "   {" +
-                "      \"field1\": \"5678\"," +
+                "      \"field1\": \"BBBB\"," +
                 "      \"field2\": \"zxcv\"" +
                 "   }" +
                 "]}";
@@ -152,7 +152,7 @@ public class FieldLevelEncryptionWithDefaultJsonEngineTest {
         String encryptedPayload = FieldLevelEncryption.encryptPayload(payload, config);
 
         // THEN
-        assertDecryptedPayloadEquals("{\"fields\":[{\"field2\":\"asdf\",\"field1\":1234},{\"field2\":\"zxcv\",\"field1\":5678}]}", encryptedPayload, config);
+        assertDecryptedPayloadEquals("{\"fields\":[{\"field2\":\"asdf\",\"field1\":\"AAAA\"},{\"field2\":\"zxcv\",\"field1\":\"BBBB\"}]}", encryptedPayload, config);
     }
 
 

--- a/src/test/java/com/mastercard/developer/encryption/JweConfigBuilderTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/JweConfigBuilderTest.java
@@ -41,6 +41,18 @@ public class JweConfigBuilderTest {
     }
 
     @Test
+    public void testBuild_ShouldBuild_WhenHavingWildcardPaths() throws Exception {
+        JweConfig config = JweConfigBuilder.aJweEncryptionConfig()
+                .withEncryptionCertificate(TestUtils.getTestEncryptionCertificate())
+                .withDecryptionKey(TestUtils.getTestDecryptionKey())
+                .withEncryptionPath("$.encryptedPayloads[*]", "$.payload[*]")
+                .withDecryptionPath("$.encryptedPayloads[*]", "$.payload[*]")
+                .withEncryptedValueFieldName("encryptedPayload")
+                .build();
+        Assert.assertNotNull(config);
+    }
+
+    @Test
     public void testBuild_ShouldComputeCertificateKeyFingerprint_WhenFingerprintNotSet() throws Exception {
         EncryptionConfig config = JweConfigBuilder.aJweEncryptionConfig()
                 .withEncryptionCertificate(TestUtils.getTestEncryptionCertificate())
@@ -78,9 +90,9 @@ public class JweConfigBuilderTest {
     }
 
     @Test
-    public void testBuild_ShouldThrowIllegalArgumentException_WhenNotDefiniteDecryptionPath() throws Exception {
+    public void testBuild_ShouldThrowIllegalArgumentException_WhenNotHavingWildcardOnBothDecryptionPaths() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("JSON paths for decryption must point to a single item!");
+        expectedException.expectMessage("JSON paths for decryption with wildcard must both contain a wildcard!");
         JweConfigBuilder.aJweEncryptionConfig()
                 .withDecryptionPath("$.encryptedPayloads[*]", "$.payload")
                 .withDecryptionKey(TestUtils.getTestDecryptionKey())
@@ -88,15 +100,35 @@ public class JweConfigBuilderTest {
     }
 
     @Test
-    public void testBuild_ShouldThrowIllegalArgumentException_WhenNotDefiniteEncryptionPath() throws Exception {
+    public void testBuild_ShouldThrowIllegalArgumentException_WhenMultipleWildcardsOnDecryptionPaths() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("JSON paths for encryption must point to a single item!");
+        expectedException.expectMessage("JSON paths for decryption with can only contain one wildcard!");
         JweConfigBuilder.aJweEncryptionConfig()
-                .withEncryptionPath("$.payloads[*]", "$.encryptedPayload")
+                .withDecryptionPath("$.encryptedPayloads[*]field1[*]subField", "$.payload[*]field1[*]encryptedSubField")
+                .withDecryptionKey(TestUtils.getTestDecryptionKey())
+                .build();
+    }
+
+    @Test
+    public void testBuild_ShouldThrowIllegalArgumentException_WhenNotHavingWildcardOnBothEncryptionPaths() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("JSON paths for encryption with wildcard must both contain a wildcard!");
+        JweConfigBuilder.aJweEncryptionConfig()
+                .withEncryptionPath("$.encryptedPayloads[*]", "$.payload")
                 .withEncryptionCertificate(TestUtils.getTestEncryptionCertificate())
                 .build();
     }
-    
+
+    @Test
+    public void testBuild_ShouldThrowIllegalArgumentException_WhenMultipleWildcardsOnEncryptionPaths() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("JSON paths for encryption with can only contain one wildcard!");
+        JweConfigBuilder.aJweEncryptionConfig()
+                .withEncryptionPath("$.encryptedPayloads[*]field1[*]subField", "$.payload[*]field1[*]encryptedSubField")
+                .withEncryptionCertificate(TestUtils.getTestEncryptionCertificate())
+                .build();
+    }
+
     @Test
     public void testBuild_ShouldNotComputeCertificateKeyFingerprint_WhenFingerprintSet() throws Exception {
         EncryptionConfig config = JweConfigBuilder.aJweEncryptionConfig()

--- a/src/test/java/com/mastercard/developer/encryption/JweEncryptionWithDefaultJsonEngineTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/JweEncryptionWithDefaultJsonEngineTest.java
@@ -39,11 +39,11 @@ public class JweEncryptionWithDefaultJsonEngineTest {
         // GIVEN
         String payload = "{ \"fields\": [" +
                 "   {" +
-                "      \"field1\": \"1234\"," +
+                "      \"field1\": \"AAAA\"," +
                 "      \"field2\": \"asdf\"" +
                 "   }," +
                 "   {" +
-                "      \"field1\": \"5678\"," +
+                "      \"field1\": \"BBBB\"," +
                 "      \"field2\": \"zxcv\"" +
                 "   }" +
                 "]}";
@@ -56,8 +56,7 @@ public class JweEncryptionWithDefaultJsonEngineTest {
         String encryptedPayload = JweEncryption.encryptPayload(payload, config);
 
         // THEN
-        JsonObject encryptedPayloadObject = new Gson().fromJson(encryptedPayload, JsonObject.class);
-        assertDecryptedJweEquals("{\"fields\":[{\"field2\":\"asdf\",\"field1\":1234},{\"field2\":\"zxcv\",\"field1\":5678}]}", encryptedPayload, config);
+        assertDecryptedJweEquals("{\"fields\":[{\"field2\":\"asdf\",\"field1\":\"AAAA\"},{\"field2\":\"zxcv\",\"field1\":\"BBBB\"}]}", encryptedPayload, config);
     }
 
     @Test

--- a/src/test/java/com/mastercard/developer/encryption/JweEncryptionWithDefaultJsonEngineTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/JweEncryptionWithDefaultJsonEngineTest.java
@@ -34,6 +34,33 @@ public class JweEncryptionWithDefaultJsonEngineTest {
     }
 
     @Test
+    public void testEncryptPayload_ShouldEncryptWithWildcard() throws Exception {
+
+        // GIVEN
+        String payload = "{ \"fields\": [" +
+                "   {" +
+                "      \"field1\": \"1234\"," +
+                "      \"field2\": \"asdf\"" +
+                "   }," +
+                "   {" +
+                "      \"field1\": \"5678\"," +
+                "      \"field2\": \"zxcv\"" +
+                "   }" +
+                "]}";
+        JweConfig config = getTestJweConfigBuilder()
+                .withEncryptionPath("$.fields[*]field1", "$.fields[*]")
+                .withDecryptionPath("$.fields[*]encryptedData", "$.fields[*]field1")
+                .build();
+
+        // WHEN
+        String encryptedPayload = JweEncryption.encryptPayload(payload, config);
+
+        // THEN
+        JsonObject encryptedPayloadObject = new Gson().fromJson(encryptedPayload, JsonObject.class);
+        assertDecryptedJweEquals("{\"fields\":[{\"field2\":\"asdf\",\"field1\":1234},{\"field2\":\"zxcv\",\"field1\":5678}]}", encryptedPayload, config);
+    }
+
+    @Test
     public void testEncryptPayload_ShouldCreateEncryptedValue_WhenOutPathParentDoesNotExistInPayload() throws Exception {
 
         // GIVEN


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: https://github.com/Mastercard/client-encryption-java/issues/52

#### Description
Adding support for wildcards on encryption and decryption paths so
path = path.to[*]foo 
obj = path.to[*]encryptedFoo
```
{ path: 
{ to : [
{foo: "Hi", foo2: "Bye"},
{foo: "Hi2", foo2: "Bye2}
]
}
}
```
will result in
```
{ path: 
{ to : [
{encryptedFoo: "encryptedJiberish", foo2: "Bye"},
{encryptedFoo: "encryptedJiberish", foo2: "Bye2}
]
}
}
```
