### PR TITLE
Updates for CVE-2023-51074 and CVE-2023-5072

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.6.0</version>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20230227</version>
+            <version>20240303</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/mastercard/developer/encryption/FieldLevelEncryption.java
+++ b/src/main/java/com/mastercard/developer/encryption/FieldLevelEncryption.java
@@ -210,7 +210,7 @@ public class FieldLevelEncryption {
         }
         JsonProvider jsonProvider = JsonParser.jsonPathConfig.jsonProvider();
         Object value = jsonProvider.getMapValue(object, key);
-        context.delete(objectPath + "." + key);
+        JsonParser.deleteIfExists(context, objectPath + "." + key);
         return value;
     }
 }

--- a/src/main/java/com/mastercard/developer/encryption/JsonParser.java
+++ b/src/main/java/com/mastercard/developer/encryption/JsonParser.java
@@ -87,11 +87,6 @@ public final class JsonParser {
         return jsonElement;
     }
 
-    // Upgrading the json-path lib from 2.6.0 to 2.9.0 introduced a bug where when you
-    // try to delete a non-existent key in a DocumentContext with the SUPPRESS_EXCEPTIONS flag,
-    // it would throw a ClassCastException. This method is a workaround for the issue.
-    // Once this issue is fixed this method's usages can be replaced with a simple DocumentContext.delete(path).
-    // Track the issue here https://github.com/json-path/JsonPath/issues/870
     static void deleteIfExists(DocumentContext context, String jsonPathString){
        Object value = context.read(jsonPathString);
        if(value != null){

--- a/src/main/java/com/mastercard/developer/encryption/JsonParser.java
+++ b/src/main/java/com/mastercard/developer/encryption/JsonParser.java
@@ -47,7 +47,7 @@ public final class JsonParser {
         int length = jsonProvider.length(decryptedValueJsonElement);
         Collection<String> propertyKeys = (0 == length) ? Collections.emptyList() : jsonProvider.getPropertyKeys(decryptedValueJsonElement);
         for (String key : propertyKeys) {
-            payloadContext.delete(jsonPathOut + "." + key);
+            deleteIfExists( payloadContext, jsonPathOut + "." + key);
             payloadContext.put(jsonPathOut, key, jsonProvider.getMapValue(decryptedValueJsonElement, key));
         }
     }
@@ -85,5 +85,17 @@ public final class JsonParser {
             throw new IllegalArgumentException(String.format("JSON object expected at path: '%s'!", jsonPathString));
         }
         return jsonElement;
+    }
+
+    // Upgrading the json-path lib from 2.6.0 to 2.9.0 introduced a bug where when you
+    // try to delete a non-existent key in a DocumentContext with the SUPPRESS_EXCEPTIONS flag,
+    // it would throw a ClassCastException. This method is a workaround for the issue.
+    // Once this issue is fixed this method's usages can be replaced with a simple DocumentContext.delete(path).
+    // Track the issue here https://github.com/json-path/JsonPath/issues/870
+    static void deleteIfExists(DocumentContext context, String jsonPathString){
+       Object value = context.read(jsonPathString);
+       if(value != null){
+           context.delete(jsonPathString);
+       }
     }
 }

--- a/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
+++ b/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
@@ -92,7 +92,7 @@ public class JweEncryption {
 
         // Delete data in clear
         if (!"$".equals(jsonPathIn)) {
-            payloadContext.delete(jsonPathIn);
+            JsonParser.deleteIfExists(payloadContext, jsonPathIn);
         } else {
             // We can't reuse the same DocumentContext. We have to create a new DocumentContext
             // with the appropriate internal representation (JSON object).
@@ -135,12 +135,12 @@ public class JweEncryption {
         }
 
         // Remove the input
-        payloadContext.delete(jsonPathIn);
+        JsonParser.deleteIfExists(payloadContext, jsonPathIn);
         return payloadContext;
     }
 
     private static Object readAndDeleteJsonKey(DocumentContext context, Object object, String key) {
-        context.delete(key);
+        JsonParser.deleteIfExists(context, key);
         return object;
     }
 

--- a/src/test/java/com/mastercard/developer/encryption/JsonParserTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/JsonParserTest.java
@@ -1,0 +1,42 @@
+package com.mastercard.developer.encryption;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+public class JsonParserTest {
+
+    @Test
+    public void testDeleteIfExists_shouldDeleteIfElementExists() {
+        final String key = "dummyKey";
+        JsonObject dummyObject = new JsonObject();
+        dummyObject.addProperty(key, "dummyValue");
+
+        DocumentContext context = JsonPath.parse(new Gson().toJson(dummyObject), JsonParser.jsonPathConfig);
+
+        JsonParser.deleteIfExists(context, key);
+
+        Object value = context.read(key);
+
+        assertNull(value);
+    }
+
+    @Test
+    public void testDeleteIfExists_doNothingIfElementDoesNotExist() {
+        final String key = "dummyKey";
+        JsonObject dummyObject = new JsonObject();
+        dummyObject.addProperty(key, "dummyValue");
+
+        DocumentContext context = JsonPath.parse(new Gson().toJson(dummyObject), JsonParser.jsonPathConfig);
+
+        JsonParser.deleteIfExists(context, "keyWhichDoesNotExist");
+
+        Object value = context.read(key);
+        assertNotNull(value);
+    }
+}


### PR DESCRIPTION
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request:  https://github.com/Mastercard/client-encryption-java/issues/90

#### Description
Updates the org.json.json and com.jayway.jsonpath.json-path libraries which fix CVE-2023-51074 and CVE-2023-5072.

Had to make code changes because the json-path library introduced a bug in the updated version which fails a few unit tests in our repo. See this PR to track the issue https://github.com/json-path/JsonPath/pull/871
