### PR TITLE
Fixing issue where JWE parent encryption node isn't removed

### DIFF
--- a/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
+++ b/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
@@ -140,7 +140,7 @@ public class JweEncryption {
         //Strip the parent node if empty
         String jsonPathInStripped = jsonPathIn.replaceAll("." + config.getEncryptedValueFieldName() + "$", "");
         Object inJsonObjectStripped = readJsonObject(payloadContext, jsonPathIn);
-        if (inJsonObjectStripped == null) {
+        if (!jsonPathInStripped.equals("$") && !jsonPathInStripped.contains("[") && inJsonObjectStripped == null) {
             JsonParser.deleteIfExists(payloadContext, jsonPathInStripped);
         }
 

--- a/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
+++ b/src/main/java/com/mastercard/developer/encryption/JweEncryption.java
@@ -136,6 +136,14 @@ public class JweEncryption {
 
         // Remove the input
         JsonParser.deleteIfExists(payloadContext, jsonPathIn);
+
+        //Strip the parent node if empty
+        String jsonPathInStripped = jsonPathIn.replaceAll("." + config.getEncryptedValueFieldName() + "$", "");
+        Object inJsonObjectStripped = readJsonObject(payloadContext, jsonPathIn);
+        if (inJsonObjectStripped == null) {
+            JsonParser.deleteIfExists(payloadContext, jsonPathInStripped);
+        }
+
         return payloadContext;
     }
 

--- a/src/test/java/com/mastercard/developer/encryption/JweEncryptionWithDefaultJsonEngineTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/JweEncryptionWithDefaultJsonEngineTest.java
@@ -115,4 +115,25 @@ public class JweEncryptionWithDefaultJsonEngineTest {
         // THEN
         assertPayloadEquals("{\"data\": {}}", payload);
     }
+
+    @Test
+    public void testDecryptPayload_ShouldRemoveParentEncryptedFieldIfEmpty() throws Exception {
+
+        // GIVEN
+        String encryptedPayload = "{\n" +
+                "    \"encryptedDataParent\": {\n" +
+                "        \"encryptedData\": \"eyJraWQiOiI3NjFiMDAzYzFlYWRlM2E1NDkwZTUwMDBkMzc4ODdiYWE1ZTZlYzBlMjI2YzA3NzA2ZTU5OTQ1MWZjMDMyYTc5IiwiY3R5IjoiYXBwbGljYXRpb24vanNvbiIsImVuYyI6IkEyNTZHQ00iLCJhbGciOiJSU0EtT0FFUC0yNTYifQ.XVy1AR51sUvwT-AtcsogQDo_klFi1EMYW8Wz7qM0e1dA3jNX5nTa38JhRcVuyVK15OenTYfg7aaH_fLjPZI1Mukd0BBnTuonh8T9CX5tbAAYx_KGPxc7a7ekBO-xXEA762eRvIIQJDZgQ_C3U39kc-XoaxC-ZYx8Va_aPBsXI1uozAfj3j5XVDnSmGAVWc2N4STTlCKbL4EO6YXASl_PrAOIVVSUrhpYvNS7GnjrP9x49tlRmTS0Dx-_MhkIAJM6H25YAuUmO-LW3gikReOUgGeY9_JtOioDs2J4ncKqugPFKr8kYF1cKnMwFv0TS9p5qR0kiF20bxRMvhbazf_Q5Q.V2Uz5-YRNq9ZIJjhRsKYIw.jB1s8rczGEj2OjU.qs4zVUf2tHML02Rglq5ncw\"\n" +
+                "    }\n" +
+                "}";
+        JweConfig config = getTestJweConfigBuilder()
+                .withEncryptedValueFieldName("encryptedData")
+                .withDecryptionPath("$.encryptedDataParent.encryptedData", "$.unencrypted")
+                .build();
+
+        // WHEN
+        String payload = JweEncryption.decryptPayload(encryptedPayload, config);
+
+        // THEN
+        assertPayloadEquals("{\"unencrypted\":{\"data\": {}}}", payload);
+    }
 }


### PR DESCRIPTION
### PR checklist

- [X] An issue/feature request has been created for this PR
- [X] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [X] File the PR against the `main` branch
- [X] The code in this PR is covered by unit tests

#### Description
Current when decrypted left over encryption fields remain.
IE 
```
{encryptedPhoneNumber : { encryptedData : akjsdfbalvfdlbgkadfg}}
```
would result in 
```
{encryptedPhoneNumber : { }, phoneNumber :{}}
```
this makes it so it's like 
```
{phoneNumber :{}}
```