### PR TITLE
Remove any combination of CR/LF line endings when reading private key

### DIFF
--- a/src/main/java/com/mastercard/developer/utils/EncryptionUtils.java
+++ b/src/main/java/com/mastercard/developer/utils/EncryptionUtils.java
@@ -64,7 +64,7 @@ public final class EncryptionUtils {
             keyDataString = keyDataString.replace(PKCS_1_PEM_HEADER, "");
             keyDataString = keyDataString.replace(PKCS_1_PEM_FOOTER, "");
             keyDataString = keyDataString.replace("\n", "");
-            keyDataString = keyDataString.replace("\r\n", "");
+            keyDataString = keyDataString.replace("\r", "");
             return readPkcs1PrivateKey(base64Decode(keyDataString));
         }
 
@@ -73,7 +73,7 @@ public final class EncryptionUtils {
             keyDataString = keyDataString.replace(PKCS_8_PEM_HEADER, "");
             keyDataString = keyDataString.replace(PKCS_8_PEM_FOOTER, "");
             keyDataString = keyDataString.replace("\n", "");
-            keyDataString = keyDataString.replace("\r\n", "");
+            keyDataString = keyDataString.replace("\r", "");
             return readPkcs8PrivateKey(base64Decode(keyDataString));
         }
 


### PR DESCRIPTION
#### Link to issue/feature request: https://github.com/Mastercard/client-encryption-java/issues/104

#### Description
RFC 7468 permits LF, CR or CRLF line endings in PEM files.

Current code first removes LF (\n) and then tries to remove CRLF (\r\n), so the CR (\n) characters are left in the file and key Base64 cannot be decoded. Because of this private key files generated/saved on Windows with CRLF line endings cannot be loaded into library.
