### PR TITLE
Decrypt data for same path

### DIFF
--- a/src/main/java/com/mastercard/developer/encryption/FieldLevelEncryption.java
+++ b/src/main/java/com/mastercard/developer/encryption/FieldLevelEncryption.java
@@ -193,10 +193,12 @@ public class FieldLevelEncryption {
             JsonParser.checkOrCreateOutObject(payloadContext, jsonPathOut);
             JsonParser.addDecryptedDataToPayload(payloadContext, decryptedValue, jsonPathOut);
 
-            // Remove the input if now empty
-            Object inJsonElement  = JsonParser.readJsonElement(payloadContext, jsonPathIn);
-            if (0 == jsonProvider.length(inJsonElement)) {
-                payloadContext.delete(jsonPathIn);
+            if(jsonPathIn != jsonPathOut) {
+                // Remove the input if now empty
+                Object inJsonElement  = JsonParser.readJsonElement(payloadContext, jsonPathIn);
+                if (0 == jsonProvider.length(inJsonElement)) {
+                    payloadContext.delete(jsonPathIn);
+                }
             }
         }
 

--- a/src/test/java/com/mastercard/developer/encryption/FieldLevelEncryptionWithDefaultJsonEngineTest.java
+++ b/src/test/java/com/mastercard/developer/encryption/FieldLevelEncryptionWithDefaultJsonEngineTest.java
@@ -709,6 +709,29 @@ public class FieldLevelEncryptionWithDefaultJsonEngineTest {
     }
 
     @Test
+    public void testDecryptPayload_ShouldDecryptPrimitiveTypes_String_ForSamePath() throws Exception {
+
+        // GIVEN
+        String encryptedPayload = "{" +
+                "    \"data\": {" +
+                "        \"iv\": \"a32059c51607d0d02e823faecda5fb15\"," +
+                "        \"encryptedKey\": \"a31cfe7a7981b72428c013270619554c1d645c04b9d51c7eaf996f55749ef62fd7c7f8d334f95913be41ae38c46d192670fd1acb84ebb85a00cd997f1a9a3f782229c7bf5f0fdf49fe404452d7ed4fd41fbb95b787d25893fbf3d2c75673cecc8799bbe3dd7eb4fe6d3f744b377572cdf8aba1617194e10475b6cd6a8dd4fb8264f8f51534d8f7ac7c10b4ce9c44d15066724b03a0ab0edd512f9e6521fdb5841cd6964e457d6b4a0e45ba4aac4e77d6bbe383d6147e751fa88bc26278bb9690f9ee84b17123b887be2dcef0873f4f9f2c895d90e23456fafb01b99885e31f01a3188f0ad47edf22999cc1d0ddaf49e1407375117b5d66f1f185f2b57078d255\"," +
+                "        \"encryptedValue\": \"21d754bdb4567d35d58720c9f8364075\"," +
+                "        \"oaepHashingAlgorithm\": \"SHA256\"" +
+                "    }" +
+                "}";
+        FieldLevelEncryptionConfig config = getTestFieldLevelEncryptionConfigBuilder()
+                .withDecryptionPath("data", "data")
+                .build();
+
+        // WHEN
+        String payload = FieldLevelEncryption.decryptPayload(encryptedPayload, config);
+
+        // THEN
+        assertPayloadEquals("{\"data\":\"string\"}", payload);
+    }
+
+    @Test
     public void testDecryptPayload_ShouldDecryptPrimitiveTypes_Integer() throws Exception {
 
         // GIVEN
@@ -722,6 +745,29 @@ public class FieldLevelEncryptionWithDefaultJsonEngineTest {
                 "}";
         FieldLevelEncryptionConfig config = getTestFieldLevelEncryptionConfigBuilder()
                 .withDecryptionPath("encryptedData", "data")
+                .build();
+
+        // WHEN
+        String payload = FieldLevelEncryption.decryptPayload(encryptedPayload, config);
+
+        // THEN
+        assertPayloadEquals("{\"data\":1984}", payload);
+    }
+
+    @Test
+    public void testDecryptPayload_ShouldDecryptPrimitiveTypes_Integer_ForSamePath() throws Exception {
+
+        // GIVEN
+        String encryptedPayload = "{" +
+                "    \"data\": {" +
+                "        \"iv\": \"5bb681fb4ca4a8f85a9c80b8f234e87c\"," +
+                "        \"encryptedKey\": \"d6819275d3a692bddce0baa10187769e0d683c351fb4e1857ab30f2572fbe1db95c34583d20ea5b224a638e99d26f6935104500b49fc1e855b7af30f34ac1d148090c6393e77e0f16d710614d00817ac862f9af730e9b3596d2c0dacf1349abd18717792ac3040f4ef1cc2e8fd9e0d685a192bfc6800e79022393eb3ce326757ba556107be28c02590390fad73117f7da3d96c05f54aaa36541b05680f23a222f1b7bbe54f1b070515dfbea8e5312708d5c27bfe9d9350e7bb72914351a6db1d83cdefee7d7514d04b73b6e285f334b27c674ad50ec830494ebc2901f1fe1738863b2d7940c98a15e1467d501545bffa724fd97b2d673e92629c9be79ca7381f\"," +
+                "        \"encryptedValue\": \"072b6ef69afd42d43b89afdf8f8bb172\"," +
+                "        \"oaepHashingAlgorithm\": \"SHA256\"" +
+                "    }" +
+                "}";
+        FieldLevelEncryptionConfig config = getTestFieldLevelEncryptionConfigBuilder()
+                .withDecryptionPath("data", "data")
                 .build();
 
         // WHEN
@@ -755,6 +801,29 @@ public class FieldLevelEncryptionWithDefaultJsonEngineTest {
     }
 
     @Test
+    public void testDecryptPayload_ShouldDecryptPrimitiveTypes_Boolean_ForSamePath() throws Exception {
+
+        // GIVEN
+        String encryptedPayload = "{" +
+                "    \"data\": {" +
+                "        \"iv\": \"683c1559d6b9366f21efc4dec682cca2\"," +
+                "        \"encryptedKey\": \"631f0729018db2aa4f02823eeac6c1bf4bc766897dfd8159ec831086acb68cf37d91427347db77869fe1088e4cd8553b5bb0308accb43e92a3977245e0005385fc538aacea323cb62d44d21c932b7fbb3fc2039de44d18fff130108b30bd5c9925a3463ace729099ce63375dfa1dd9ec9f1e277de6b4ace5161a0e47ae81908aa2f8b44a654be2b863d6dfc5112a422dda065d8fbc0d5e47ea435409262c608edfc28a49e90fbda035c1743ec8cabd453d75775b0ab7b660b20b3a1f37c6eecffa32a26b07adf78432e1dd479a2ce19002846cb2fa2488ade423265ce7c4b003373837971c7b803925624f8eeb9254dad347941ebab8f641522b5b1efe53f572\"," +
+                "        \"encryptedValue\": \"cc8bb0cc778d508f198c39364cce9137\"," +
+                "        \"oaepHashingAlgorithm\": \"SHA256\"" +
+                "    }" +
+                "}";
+        FieldLevelEncryptionConfig config = getTestFieldLevelEncryptionConfigBuilder()
+                .withDecryptionPath("data", "data")
+                .build();
+
+        // WHEN
+        String payload = FieldLevelEncryption.decryptPayload(encryptedPayload, config);
+
+        // THEN
+        assertPayloadEquals("{\"data\":false}", payload);
+    }
+
+    @Test
     public void testDecryptPayload_ShouldDecryptArrayFields() throws Exception {
 
         // GIVEN
@@ -768,6 +837,29 @@ public class FieldLevelEncryptionWithDefaultJsonEngineTest {
                 "}";
         FieldLevelEncryptionConfig config = getTestFieldLevelEncryptionConfigBuilder()
                 .withDecryptionPath("$.encryptedItems", "$.items")
+                .build();
+
+        // WHEN
+        String payload = FieldLevelEncryption.decryptPayload(encryptedPayload, config);
+
+        // THEN
+        assertPayloadEquals("{\"items\":[{},{}]}", payload);
+    }
+
+    @Test
+    public void testDecryptPayload_ShouldDecryptArrayFields_ForSamePath() throws Exception {
+
+        // GIVEN
+        String encryptedPayload = "{" +
+                "    \"items\": {" +
+                "        \"iv\": \"34010a3ea7231126a0d1e088ec8db173\"," +
+                "        \"encryptedKey\": \"072aee9f7dd6cf381eb61e6d93c2e19e4032e1166d36d3ccb32ec379815f472e27d82a0de48617ff440d37a534bb38b170cf236a78148a375971e83b087eb7d05807863e70b43baa446934fe6f70150e3ca4e49e70fecabb1969c1fc5a38f13a75e318077760e4fe53e25ca011781d1038d19bb3a16928d35302bc7e389c8fb089230b8c0acc3c7e59c120cfe3aece6ff346aaa598a2baf003026f0a32307af022b9515fea564bb5d491b0159b20d909deb9cb5e8077d6471ad1ad3d7e743d6c3cf09f999c22006038980268b9d0cac1fd2e53b1a6e8e4d63b0a3e4457ff27ffab7cd025011b678e0ff56537c29e81ed087fe11988c2c92a7c7695f1fc6f856a\"," +
+                "        \"encryptedValue\": \"d91268566c92621d394b5e5d94069387\"," +
+                "        \"oaepHashingAlgorithm\": \"SHA256\"" +
+                "    }" +
+                "}";
+        FieldLevelEncryptionConfig config = getTestFieldLevelEncryptionConfigBuilder()
+                .withDecryptionPath("$.items", "$.items")
                 .build();
 
         // WHEN


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `main` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: https://github.com/Mastercard/client-encryption-java/issues/110

#### Description
Fix decrypt primitive types like integer and boolean for same decryption path.
Validate if the jsonPathIn and the jsonPathOut are the same. If yes, dont remove the path from payloadContext
